### PR TITLE
Fix instance state

### DIFF
--- a/services/jenkins-autoscaling/lambda_mxnet_ci/autoscaling/handler.py
+++ b/services/jenkins-autoscaling/lambda_mxnet_ci/autoscaling/handler.py
@@ -417,7 +417,7 @@ def _unconnected_instances(nodes: list, instance_uptime: Dict[str, int], ec2_res
     dict_starting_nodes: Dict[str, List[str]] = defaultdict(list)
     instances_filter = ec2_resource.instances.filter(
         Filters=[
-            {'Name': 'instance-state-name', 'Values': ['starting', 'running']},
+            {'Name': 'instance-state-name', 'Values': ['pending', 'running']},
             {'Name': 'tag:AutoScaledSlave', 'Values': ['True']}  # Ensure only listing instances managed by auto scaling
         ])
     for instance in instances_filter:


### PR DESCRIPTION
According to EC2 Instance Lifecycle, permissible states are "pending" and "running"
There is no such state as "starting"
It's a bug.