### PR TITLE
Update C5 Jenkins slave creation scripts

### DIFF
--- a/tools/jenkins-slave-creation-unix/conf-ubuntu-cpu-c5/infrastructure.tfvars
+++ b/tools/jenkins-slave-creation-unix/conf-ubuntu-cpu-c5/infrastructure.tfvars
@@ -19,16 +19,11 @@ key_name = "REDACTED"
 key_path = "~/.ssh/REDACTED"
 instance_type = "c5.18xlarge"
 
-additional_security_group_ids = [
-  "sg-5d83d421", # VPC default
-  "sg-REDACTED" # REDACTED
-]
-
 s3_config_bucket = "mxnet-ci-slave-dev"
 s3_config_filename = "ubuntu-cpu-c5-config.tar.bz2"
 slave_install_script  = "conf-ubuntu-cpu-c5/install.sh"
 shell_variables_file = "conf-ubuntu-cpu-c5/shell-variables.sh"
-ami = "ami-bd8f33c5" # ftp://64.50.236.216/pub/ubuntu-cloud-images/query/xenial/server/released.txt
+ami = "ami-0d1cd67c26f5fca19" # Ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200112
 instance_name = "Slave-base_Ubuntu-CPU-C5"
 aws_region = "us-west-2"
 secret_manager_docker_hub_arn = "arn:aws:secretsmanager:us-west-2:REDACTED:secret:REDACTED"

--- a/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu-g3/infrastructure.tfvars
+++ b/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu-g3/infrastructure.tfvars
@@ -19,11 +19,6 @@ key_name = "REDACTED"
 key_path = "~/.ssh/REDACTED"
 instance_type = "g3.8xlarge"
 
-additional_security_group_ids = [
-  "sg-5d83d421", # VPC default
-  "REDACTED" # REDACTED
-]
-
 s3_config_bucket = "mxnet-ci-slave-dev"
 s3_config_filename = "ubuntu-gpu-g3-config.tar.bz2"
 slave_install_script  = "conf-ubuntu-gpu-g3/install.sh"

--- a/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu-g3/install.sh
+++ b/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu-g3/install.sh
@@ -29,7 +29,7 @@ whoami
 sudo useradd jenkins_slave
 
 #Prevent log in
-sudo usermod -L jenkins_slave
+sudo usermod -L jenkins_slave 
 sudo mkdir -p /home/jenkins_slave/remoting
 sudo chown -R jenkins_slave:jenkins_slave /home/jenkins_slave
 
@@ -38,15 +38,8 @@ sudo apt-get -y purge openjdk*
 sudo apt-get -y purge nvidia*
 echo "Purged packages"
 
-#Add third party repositories
-sudo add-apt-repository -y ppa:graphics-drivers/ppa
-sudo curl -fsSL https://apt.dockerproject.org/gpg | sudo apt-key add -
-sudo apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
-sudo add-apt-repository "deb https://apt.dockerproject.org/repo/  ubuntu-xenial main"
-sudo apt-get update
-echo "Added third party repositories"
-
 #Install htop
+sudo apt-get update
 sudo apt-get -y install htop
 
 #Install java
@@ -64,7 +57,7 @@ sudo pip3 install boto3 python-jenkins joblib docker
 echo "Installed htop, java, git and python"
 
 #Install nvidia drivers
-sudo apt-get -y install nvidia-410
+sudo apt-get -y install nvidia-418
 
 # TODO: - Disabled nvidia updates @ /etc/apt/apt.conf.d/50unattended-upgrades
 #Unattended-Upgrade::Package-Blacklist {

--- a/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu-p3/infrastructure.tfvars
+++ b/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu-p3/infrastructure.tfvars
@@ -19,11 +19,6 @@ key_name = "REDACTED"
 key_path = "~/.ssh/REDACTED"
 instance_type = "p3.2xlarge"
 
-additional_security_group_ids = [
-  "sg-5d83d421", # VPC default
-  "sg-REDACTED" # REDACTED
-]
-
 s3_config_bucket = "mxnet-ci-slave-dev"
 s3_config_filename = "ubuntu-gpu-p3-config.tar.bz2"
 slave_install_script  = "conf-ubuntu-gpu-p3/install.sh"

--- a/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu-p3/install.sh
+++ b/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu-p3/install.sh
@@ -36,15 +36,8 @@ sudo apt-get -y purge openjdk*
 sudo apt-get -y purge nvidia*
 echo "Purged packages"
 
-#Add third party repositories
-sudo add-apt-repository -y ppa:graphics-drivers/ppa
-sudo curl -fsSL https://apt.dockerproject.org/gpg | sudo apt-key add -
-sudo apt-key fingerprint 58118E89F3A912897C070ADBF76221572C52609D
-sudo add-apt-repository "deb https://apt.dockerproject.org/repo/  ubuntu-xenial main"
-sudo apt-get update
-echo "Added third party repositories"
-
 #Install htop
+sudo apt-get update
 sudo apt-get -y install htop
 
 #Install java
@@ -62,7 +55,7 @@ sudo pip3 install boto3 python-jenkins joblib docker
 echo "Installed htop, java, git and python"
 
 #Install nvidia drivers
-sudo apt-get -y install nvidia-410
+sudo apt-get -y install nvidia-418
 
 # TODO: - Disabled nvidia updates @ /etc/apt/apt.conf.d/50unattended-upgrades
 #Unattended-Upgrade::Package-Blacklist {

--- a/tools/jenkins-slave-creation-unix/infrastructure.tf
+++ b/tools/jenkins-slave-creation-unix/infrastructure.tf
@@ -27,10 +27,6 @@ variable "instance_type" {
   type = "string"
 }
 
-variable "additional_security_group_ids" {
-  type = "list"
-}
-
 variable "secret_manager_docker_hub_arn" {
   type = "string"
 }
@@ -95,7 +91,7 @@ data "template_cloudinit_config" "user_data" {
         content = "${file("${var.shell_variables_file}")}"
     }
 
-
+	
     part {
         content_type = "text/x-shellscript"
         content = "${file("${var.slave_install_script}")}"
@@ -184,7 +180,7 @@ resource "aws_iam_policy" "jenkins_slave_s3_read_policy" {
             ]
         }
 
-
+        
     ]
 }
 POLICY
@@ -217,7 +213,7 @@ resource "aws_iam_policy" "jenkins_slave_ec2_create_tags" {
             ]
         }
 
-
+        
     ]
 }
 POLICY
@@ -288,19 +284,18 @@ resource "aws_instance" "mxnet-slave" {
   #
   key_name = "${var.key_name}"
 
-  vpc_security_group_ids =  ["${
-    concat(
-      var.additional_security_group_ids
-    )
-  }"]
+  vpc_security_group_ids =  [
+    "REDACTED",
+    "REDACTED"
+  ]
 
   user_data = "${data.template_cloudinit_config.user_data.rendered}"
 
-  tags {
+  tags = {
     "Name" = "${var.instance_name}"
   }
 
-
+  
   root_block_device {
     volume_type = "gp2"
     volume_size = 350
@@ -322,5 +317,5 @@ resource "aws_s3_bucket_object" "slave_config_s3" {
   bucket = "${aws_s3_bucket.slave_config_bucket.id}"
   key    = "${var.s3_config_filename}"
   source = "${var.slave_config_tar_path}"
-  etag   = "${md5(file(var.slave_config_tar_path))}"
+  etag   = "${filemd5(var.slave_config_tar_path)}"
 }


### PR DESCRIPTION
- Add qemu for virtualization
- Update to Ubuntu 18.04 (require at least 4.8 kernel for qemu)
- Switch to docker package from Ubuntu's repo

The docker.io package from Ubuntu is superior from a packaging perspective, but there are no substantial differences for our usage. I also tested with the docker-ce package, but both faced the https://github.com/docker/docker-py/issues/2266 problem. 
See https://stackoverflow.com/a/57678382/2560672 for discussion of problems with docker-ce package.

Also fix syntax errors in Terraform, due to Terraform removing previously used
syntax features.