### PR TITLE
Add the empty string assignment to execstart

### DIFF
--- a/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu/install.sh
+++ b/tools/jenkins-slave-creation-unix/conf-ubuntu-gpu/install.sh
@@ -113,6 +113,7 @@ sudo apt-get install nvidia-container-runtime
 sudo mkdir -p /etc/systemd/system/docker.service.d
 sudo tee /etc/systemd/system/docker.service.d/override.conf <<EOF
 [Service]
+ExecStart=
 ExecStart=/usr/bin/dockerd --host=fd:// --add-runtime=nvidia=/usr/bin/nvidia-container-runtime
 EOF
 sudo systemctl daemon-reload


### PR DESCRIPTION
Based on the comment here

https://github.com/NVIDIA/nvidia-container-runtime/pull/97#issuecomment-627561927

https://www.freedesktop.org/software/systemd/man/systemd.service.html

>    If the empty string is assigned to this option, the list of commands to start is reset, prior assignments of this option will have no effect.
