### PR TITLE
Update latest build selection and log when one build fails

### DIFF
--- a/services/jenkins-pipeline-monitor/handler.py
+++ b/services/jenkins-pipeline-monitor/handler.py
@@ -11,7 +11,7 @@ logging.getLogger().setLevel(logging.INFO)
 logging.getLogger('boto3').setLevel(logging.CRITICAL)
 logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
-desired_release_job_type = ['mxnet_lib/static', 'python/pypi']
+release_job_type = ['mxnet_lib/static', 'python/pypi']
 
 def get_jenkins_obj(secret):
     """
@@ -86,10 +86,10 @@ def get_release_job_type(build):
     return build.get_params()['RELEASE_JOB_TYPE']
 
 
-def filter_by_desired_release_job_type(latest_day_builds, desired_release_job_type):
+def filter_by_release_job_type(latest_day_builds):
     filtered_builds = []
     for build in latest_day_builds:
-        if get_release_job_type(build) in desired_release_job_type:
+        if get_release_job_type(build) in release_job_type:
             filtered_builds.append(build)
     return filtered_builds
 
@@ -102,7 +102,7 @@ def status_check(builds):
     :param builds
     """
     if not builds:
-        for job_type in desired_release_job_type:
+        for job_type in release_job_type:
             logging.info(f'Failure build {job_type}')
     else:
         for build in builds:
@@ -141,7 +141,7 @@ def jenkins_pipeline_monitor():
     latest_day_builds = get_latest_day_builds(job, latest_build_number)
     logging.info(f'latest builds {latest_day_builds}')
     # filter latest day builds by desired build type a.k.a release job type
-    filtered_builds = filter_by_desired_release_job_type(latest_day_builds, desired_release_job_type)
+    filtered_builds = filter_by_release_job_type(latest_day_builds)
     logging.info(f'Builds filtered by desired release job type : {filtered_builds}')
 
     desired_cause = 'hudson.model.Cause$UpstreamCause'

--- a/services/jenkins-pipeline-monitor/handler.py
+++ b/services/jenkins-pipeline-monitor/handler.py
@@ -104,6 +104,8 @@ def status_check(builds):
     """
     # dictionary of the type release_job_type: count
     # e.g. {'mxnet_lib/static':0, 'python/pypi':0}
+    global release_job_type
+    success_count = 0
     release_job_type_dict = {el : 0 for el in release_job_type}
 
     # iterate over the builds to count number of the desirect release job types
@@ -119,9 +121,9 @@ def status_check(builds):
     # iterate over the map of release_job_type: count
     # if 'mxnet_lib/static':1 indicates static jobtype job ran in the pipeline
     # else 'mxnet_lib/static':0 indicates static jobtype never ran -> log as failed
-    for release_job_type, release_job_type_count in release_job_type_dict.items():
+    for release_job_type_name, release_job_type_count in release_job_type_dict.items():
         if release_job_type_count == 0:
-            logging.info(f'Failure build {release_job_type}')
+            logging.info(f'Failure build {release_job_type_name}')
         elif release_job_type_count == 1:
             success_count += 1
         else:

--- a/services/jenkins-pipeline-monitor/handler.py
+++ b/services/jenkins-pipeline-monitor/handler.py
@@ -98,7 +98,7 @@ def status_check(builds):
     """
     Check the status of the filtered builds
     i.e. Check if all the required release job types are present in the pipeline
-    If there is not a single build from the list of desired release job types, log the failures
+    If a build from the list of desired release job types doesn't exist, log the failure
     else check the status via Jenkins API and report accordingly
     :param builds
     """
@@ -106,17 +106,16 @@ def status_check(builds):
     # e.g. {'mxnet_lib/static':0, 'python/pypi':0}
     global release_job_type
     success_count = 0
-    release_job_type_dict = {el : 0 for el in release_job_type}
+    release_job_type_dict = {el: 0 for el in release_job_type}
 
-    # iterate over the builds to count number of the desirect release job types
+    # iterate over the builds to count number of the desired release job types
     for build in builds:
         build_release_job_type = get_release_job_type(build)
-        if build_release_job_type in release_job_type_dict:
-            if build.get_status() == 'SUCCESS':
-                logging.info(f'Successful build {build_release_job_type} {build.get_number()}')
-            else:
-                logging.info(f'Failure build {build_release_job_type} {build.get_number()}')
-            release_job_type_dict[build_release_job_type] += 1
+        if build.get_status() == 'SUCCESS':
+            logging.info(f'Successful build {build_release_job_type} {build.get_number()}')
+        else:
+            logging.info(f'Failure build {build_release_job_type} {build.get_number()}')
+        release_job_type_dict[build_release_job_type] += 1
 
     # iterate over the map of release_job_type: count
     # if 'mxnet_lib/static':1 indicates static jobtype job ran in the pipeline


### PR DESCRIPTION
Based on the discussion in the previous PR 
https://github.com/apache/incubator-mxnet-ci/pull/25#discussion_r427626182

Build selection from the latest day logic is now set to span 24hours instead of 8.
This ensures regardless of what time the Lambda is triggered / Jenkins pipeline is triggered, all the builds in the last 24 hours will be considered.

Another corner case is handled in this PR
When the initial 2 stages of the mxnet-release-cd pipeline fail, it doesn't trigger the subsequent 2 stages ['mxnet_lib/static', 'python/pypi']
This doesn't get logged as a result it doesn't get captured by the Alarm.
Addressing it here.