### PR TITLE
Updates to AMI creation utility and autoscaling lambda

### DIFF
--- a/tools/ami-creator/scripts/run-auto-connect.bat
+++ b/tools/ami-creator/scripts/run-auto-connect.bat
@@ -1,0 +1,3 @@
+cd C:\
+
+C:\Python38\python.exe .\slave-autoconnect.py --slave-name-file=C:\jenkins_slave\jenkins_slave_name.txt --master-file=C:\jenkins_slave\jenkins_master_url.txt --master-private-file=C:\jenkins_slave\jenkins_master_private_url.txt

--- a/tools/ami-creator/scripts/win2019_cuda114_installer.py
+++ b/tools/ami-creator/scripts/win2019_cuda114_installer.py
@@ -224,6 +224,7 @@ def install_vs():
                ' --add Microsoft.VisualStudio.Component.Static.Analysis.Tools'
                ' --add Microsoft.VisualStudio.Component.VC.CMake.Project'
                ' --add Microsoft.VisualStudio.Component.VC.140'
+               ' --add Microsoft.VisualStudio.Component.VC.14.28.x86.x64'
                ' --add Microsoft.VisualStudio.Component.Windows10SDK.18362.Desktop'
                ' --add Microsoft.VisualStudio.Component.Windows10SDK.18362.UWP'
                ' --add Microsoft.VisualStudio.Component.Windows10SDK.18362.UWP.Native'

--- a/tools/ami-creator/userdata/mxnetlinux_cpu_aarch64_ubuntu_2004.txt
+++ b/tools/ami-creator/userdata/mxnetlinux_cpu_aarch64_ubuntu_2004.txt
@@ -1,0 +1,75 @@
+#cloud-config
+
+apt_reboot_if_required: false
+package_update: true
+package_upgrade: true
+
+packages:
+  - htop
+  - wget
+  - openjdk-8-jre
+  - git
+  - python3
+  - python3-pip
+  - python3-yaml
+  - python3-jenkins
+  - python3-joblib
+  - docker.io
+  - awscli
+  - nfs-common
+  - libattr1-dev
+
+write_files:
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "live-restore": true
+      }
+  - path: /etc/cron.d/jenkins-start-slave
+    content: |
+      @reboot jenkins_slave /home/jenkins_slave/scripts/launch-autoconnect.sh
+  - path: /etc/cron.d/apt-update-on-startup
+    content: |
+      @reboot root /root/apt_update_startup.sh
+  - path: /root/apt_update_startup.sh
+    content: |
+      export DEBIAN_FRONTEND=noninteractive
+      apt update
+      apt upgrade -y
+      touch /tmp/apt.done
+  - path: /home/jenkins_slave/scripts/launch-autoconnect.sh
+    content: |
+      #!/bin/sh
+      set -ex
+      while [ ! -e /tmp/apt.done ]; do sleep 5; done
+      python3 /home/jenkins_slave/scripts/slave-autoconnect.py --slave-name-file=/home/jenkins_slave/jenkins_slave_name --master-file=/home/jenkins_slave/jenkins_master_url --master-private-file=/home/jenkins_slave/jenkins_master_private_url > /home/jenkins_slave/auto-connect.log
+  - path: /etc/fstab
+    content: |
+      /swapfile none swap sw 0 0
+    append: true
+
+
+runcmd:
+  - [ "fallocate", "-l", "10G", "/swapfile" ]
+  - [ "chown", "root:root", "/swapfile" ]
+  - [ "chmod", "0600", "/swapfile" ]
+  - [ "mkswap", "/swapfile" ]
+  - [ "swapon", "/swapfile" ]
+  - [ "useradd", "jenkins_slave" ]
+  - [ "usermod", "-L", "jenkins_slave" ]
+  - [ "mkdir", "-p", "/home/jenkins_slave/remoting", "/home/jenkins_slave/scripts" ]
+  - [ "pip3", "install", "docker<4.0.0", "boto3" ]
+  - [ "pip3", "install", "--upgrade", "awscli" ]
+  - [ "usermod", "-aG", "docker", "jenkins_slave" ]
+  - [ "systemctl", "enable", "docker" ]
+  - [ "wget", "-O", "/home/jenkins_slave/scripts/slave-autoconnect.py", "https://raw.githubusercontent.com/apache/incubator-mxnet-ci/master/tools/jenkins-slave-creation-unix/scripts/deploy/slave-autoconnect.py" ]
+  - [ "touch", "/home/jenkins_slave/auto-connect.log" ]
+  - [ "chown", "-R", "jenkins_slave:jenkins_slave", "/home/jenkins_slave" ]
+  - [ "chmod", "+x", "/home/jenkins_slave/scripts/slave-autoconnect.py", "/home/jenkins_slave/scripts/launch-autoconnect.sh", "/root/apt_update_startup.sh" ]
+  - [ "curl", "-L", "https://github.com/docker/compose/releases/download/v2.2.2/docker-compose-linux-aarch64", "-o", "/usr/bin/docker-compose" ]
+  - [ "chmod", "+x", "/usr/bin/docker-compose" ]
+  - [ "rm", "-f", "/var/lib/cloud/instances/*/sem/config_scripts_user", "/var/lib/cloud/instance/sem/config_scripts_user" ]
+  - [ "rm", "-f", "/tmp/apt.done" ]
+  - [ "sleep", "10" ]
+  - [ "halt", "-p" ]
+

--- a/tools/ami-creator/userdata/mxnetlinux_cpu_ubuntu_2004.txt
+++ b/tools/ami-creator/userdata/mxnetlinux_cpu_ubuntu_2004.txt
@@ -31,10 +31,20 @@ write_files:
   - path: /etc/cron.d/jenkins-start-slave
     content: |
       @reboot jenkins_slave /home/jenkins_slave/scripts/launch-autoconnect.sh
+  - path: /etc/cron.d/apt-update-on-startup
+    content: |
+      @reboot root /root/apt_update_startup.sh
+  - path: /root/apt_update_startup.sh
+    content: |
+      export DEBIAN_FRONTEND=noninteractive
+      apt update
+      apt upgrade -y
+      touch /tmp/apt.done
   - path: /home/jenkins_slave/scripts/launch-autoconnect.sh
     content: |
       #!/bin/sh
       set -ex
+      while [ ! -e /tmp/apt.done ]; do sleep 5; done
       python3 /home/jenkins_slave/scripts/slave-autoconnect.py --slave-name-file=/home/jenkins_slave/jenkins_slave_name --master-file=/home/jenkins_slave/jenkins_master_url --master-private-file=/home/jenkins_slave/jenkins_master_private_url > /home/jenkins_slave/auto-connect.log
   - path: /etc/fstab
     content: |
@@ -58,13 +68,14 @@ runcmd:
   - [ "wget", "-O", "/home/jenkins_slave/scripts/slave-autoconnect.py", "https://raw.githubusercontent.com/apache/incubator-mxnet-ci/master/tools/jenkins-slave-creation-unix/scripts/deploy/slave-autoconnect.py" ]
   - [ "touch", "/home/jenkins_slave/auto-connect.log" ]
   - [ "chown", "-R", "jenkins_slave:jenkins_slave", "/home/jenkins_slave" ]
-  - [ "chmod", "+x", "/home/jenkins_slave/scripts/slave-autoconnect.py", "/home/jenkins_slave/scripts/launch-autoconnect.sh" ]
+  - [ "chmod", "+x", "/home/jenkins_slave/scripts/slave-autoconnect.py", "/home/jenkins_slave/scripts/launch-autoconnect.sh", "/root/apt_update_startup.sh" ]
   - [ "curl", "-L", "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-Linux-x86_64", "-o", "/usr/bin/docker-compose" ]
   - [ "chmod", "+x", "/usr/bin/docker-compose" ]
   - [ "wget", "-O", "/tmp/qemu-binfmt-conf.sh", "https://raw.githubusercontent.com/qemu/qemu/stable-4.1/scripts/qemu-binfmt-conf.sh" ]
   - [ "chmod", "+x", "/tmp/qemu-binfmt-conf.sh" ]
   - [ "/tmp/qemu-binfmt-conf.sh", "--persistent", "yes", "--qemu-suffix", "-static", "--qemu-path", "/usr/bin", "--systemd", "ALL" ]
   - [ "rm", "-f", "/var/lib/cloud/instances/*/sem/config_scripts_user", "/var/lib/cloud/instance/sem/config_scripts_user" ]
+  - [ "rm", "-f", "/tmp/apt.done" ]
   - [ "sleep", "10" ]
   - [ "halt", "-p" ]
 

--- a/tools/ami-creator/userdata/mxnetlinux_gpu_ubuntu_2004.txt
+++ b/tools/ami-creator/userdata/mxnetlinux_gpu_ubuntu_2004.txt
@@ -40,10 +40,20 @@ write_files:
   - path: /etc/cron.d/jenkins-start-slave
     content: |
       @reboot jenkins_slave /home/jenkins_slave/scripts/launch-autoconnect.sh
+  - path: /etc/cron.d/apt-update-on-startup
+    content: |
+      @reboot root /root/apt_update_startup.sh
+  - path: /root/apt_update_startup.sh
+    content: |
+      export DEBIAN_FRONTEND=noninteractive
+      apt update
+      apt upgrade -y
+      touch /tmp/apt.done
   - path: /home/jenkins_slave/scripts/launch-autoconnect.sh
     content: |
       #!/bin/sh
       set -ex
+      while [ ! -e /tmp/apt.done ]; do sleep 5; done
       python3 /home/jenkins_slave/scripts/slave-autoconnect.py --slave-name-file=/home/jenkins_slave/jenkins_slave_name --master-file=/home/jenkins_slave/jenkins_master_url --master-private-file=/home/jenkins_slave/jenkins_master_private_url > /home/jenkins_slave/auto-connect.log
   - path: /etc/fstab
     content: |
@@ -68,13 +78,14 @@ runcmd:
   - [ "wget", "-O", "/home/jenkins_slave/scripts/slave-autoconnect.py", "https://raw.githubusercontent.com/apache/incubator-mxnet-ci/master/tools/jenkins-slave-creation-unix/scripts/deploy/slave-autoconnect.py" ]
   - [ "touch", "/home/jenkins_slave/auto-connect.log" ]
   - [ "chown", "-R", "jenkins_slave:jenkins_slave", "/home/jenkins_slave" ]
-  - [ "chmod", "+x", "/home/jenkins_slave/scripts/slave-autoconnect.py", "/home/jenkins_slave/scripts/launch-autoconnect.sh" ]
+  - [ "chmod", "+x", "/home/jenkins_slave/scripts/slave-autoconnect.py", "/home/jenkins_slave/scripts/launch-autoconnect.sh", "/root/apt_update_startup.sh" ]
   - [ "usermod", "-aG", "docker", "jenkins_slave" ]
   - [ "systemctl", "enable", "docker" ]
   - [ "service", "docker", "restart" ]
   - [ "curl", "-L", "https://github.com/docker/compose/releases/download/1.25.5/docker-compose-Linux-x86_64", "-o", "/usr/bin/docker-compose" ]
   - [ "chmod", "+x", "/usr/bin/docker-compose" ]
   - [ "rm", "-f", "/var/lib/cloud/instances/*/sem/config_scripts_user", "/var/lib/cloud/instance/sem/config_scripts_user" ]
+  - [ "rm", "-f", "/tmp/apt.done" ]
   - [ "sleep", "10" ]
   - [ "halt", "-p" ]
 


### PR DESCRIPTION
- Update lambda autoscaler to remove windows hourly-billing workarounds
- add jenkins new name for built-in (formerly master) node
- change launch parameters to use default launch template version instead of using environment variables to specify specific version, to minimize maintenance effort
- update descriptions of worker nodes
- Add aarch64 userdata for building graviton-based jenkins worker AMIs
- Update userdata templates to perform an apt upgrade on bootup, before starting jenkins runner, to prevent auto-updates by SSM restarting services (such as docker) that may currently be in-use by jenkins jobs
- Update windows installer script to install the correct VC runtime
- Update AMI create util with the ability to update launch templates (and set the default version) after building a new AMI
